### PR TITLE
macOS build fixes

### DIFF
--- a/addons/freightcar/freightcar/CMakeLists.txt
+++ b/addons/freightcar/freightcar/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/addons/passcar/passcar/CMakeLists.txt
+++ b/addons/passcar/passcar/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/addons/vl60/vl60-autopilot/CMakeLists.txt
+++ b/addons/vl60/vl60-autopilot/CMakeLists.txt
@@ -22,7 +22,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/addons/vl60/vl60k/CMakeLists.txt
+++ b/addons/vl60/vl60k/CMakeLists.txt
@@ -26,7 +26,7 @@ file (GLOB SOURCES "./src/*.cpp")
 file (GLOB EQP_SOURCES "../vl60-equipment/src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/addons/vl60/vl60pk/CMakeLists.txt
+++ b/addons/vl60/vl60pk/CMakeLists.txt
@@ -26,7 +26,7 @@ file (GLOB SOURCES "./src/*.cpp")
 file (GLOB EQP_SOURCES "../vl60-equipment/src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES} ${EQP_SOURCES} ${EQP_INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/docs/BUILD_MACOS.md
+++ b/docs/BUILD_MACOS.md
@@ -1,0 +1,92 @@
+# Сборка RRS на macOS
+
+Проверено: macOS 26.3, Apple Silicon (arm64), AppleClang 17.
+
+## Зависимости
+
+### Homebrew
+
+```bash
+brew install cmake qt@6 openal-soft sfml molten-vk \
+             vulkan-headers vulkan-loader glslang assimp freetype
+```
+
+### Сборка из исходников
+
+```bash
+DEPS=$HOME/RRS-deps
+PREFIX=$DEPS/install
+mkdir -p $DEPS && cd $DEPS
+```
+
+**VulkanSceneGraph:**
+```bash
+git clone https://github.com/vsg-dev/VulkanSceneGraph.git
+cd VulkanSceneGraph
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX
+cmake --build build -j$(sysctl -n hw.ncpu) && cmake --install build
+cd $DEPS
+```
+
+**vsgXchange:**
+```bash
+git clone https://github.com/vsg-dev/vsgXchange.git
+cd vsgXchange
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX
+cmake --build build -j$(sysctl -n hw.ncpu) && cmake --install build
+cd $DEPS
+```
+
+**vsgImGui:**
+```bash
+git clone https://github.com/maisvendoo/vsgImGui.git
+cd vsgImGui
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX
+cmake --build build -j$(sysctl -n hw.ncpu) && cmake --install build
+cd $DEPS
+```
+
+**Lua 5.4:**
+```bash
+git clone https://github.com/maisvendoo/lua-cmake.git
+cd lua-cmake
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX
+cmake --build build -j$(sysctl -n hw.ncpu) && cmake --install build
+cd $DEPS
+```
+
+**sol2:**
+```bash
+git clone https://github.com/maisvendoo/sol2.git
+cd sol2
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX
+cmake --build build -j$(sysctl -n hw.ncpu) && cmake --install build
+```
+
+## Сборка RRS
+
+```bash
+cd /path/to/RRS
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH="$HOME/RRS-deps/install;/opt/homebrew/opt/openal-soft;/opt/homebrew"
+cmake --build build -j$(sysctl -n hw.ncpu)
+```
+
+Результат: исполняемые файлы в `bin/`, библиотеки в `lib/`.
+
+## Запуск
+
+```bash
+cd bin/
+
+# Терминал 1 — симулятор
+./simulator --route experimental-polygon_v2.0 --scenario hello_scenario
+
+# Терминал 2 — вьювер
+VK_ICD_FILENAMES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json \
+QT_QPA_PLATFORM=offscreen \
+./viewer
+```
+
+`VK_ICD_FILENAMES` — путь к ICD MoltenVK (keg-only в Homebrew).
+`QT_QPA_PLATFORM=offscreen` — обход конфликта NSApp между Qt и VSG.

--- a/simulator/ar265/CMakeLists.txt
+++ b/simulator/ar265/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/connector-ALSN/CMakeLists.txt
+++ b/simulator/connector-ALSN/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/connector-speedmap/CMakeLists.txt
+++ b/simulator/connector-speedmap/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/epk150/CMakeLists.txt
+++ b/simulator/epk150/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/euler/CMakeLists.txt
+++ b/simulator/euler/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/euler2/CMakeLists.txt
+++ b/simulator/euler2/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/evr305/CMakeLists.txt
+++ b/simulator/evr305/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/freejoy/CMakeLists.txt
+++ b/simulator/freejoy/CMakeLists.txt
@@ -34,7 +34,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/hose369a/CMakeLists.txt
+++ b/simulator/hose369a/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/joint-coupling-sa3/CMakeLists.txt
+++ b/simulator/joint-coupling-sa3/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/joint-coupling/CMakeLists.txt
+++ b/simulator/joint-coupling/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/joint-pneumo-hose-epb/CMakeLists.txt
+++ b/simulator/joint-pneumo-hose-epb/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/joint-pneumo-hose/CMakeLists.txt
+++ b/simulator/joint-pneumo-hose/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/krm130/CMakeLists.txt
+++ b/simulator/krm130/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/krm395/CMakeLists.txt
+++ b/simulator/krm395/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/kvt224/CMakeLists.txt
+++ b/simulator/kvt224/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/kvt254/CMakeLists.txt
+++ b/simulator/kvt254/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/modbus/CMakeLists.txt
+++ b/simulator/modbus/CMakeLists.txt
@@ -29,7 +29,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/rk4/CMakeLists.txt
+++ b/simulator/rk4/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/rkf5/CMakeLists.txt
+++ b/simulator/rkf5/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/sa3/CMakeLists.txt
+++ b/simulator/sa3/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/trajectory-ALSN/CMakeLists.txt
+++ b/simulator/trajectory-ALSN/CMakeLists.txt
@@ -28,13 +28,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-if(APPLE)
-    # On macOS MODULE libraries can't be linked to by other targets.
-    # trajectory-ALSN is linked by connector-ALSN, so it must be SHARED.
-    add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
-else()
-    add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
-endif()
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/trajectory-speedmap/CMakeLists.txt
+++ b/simulator/trajectory-speedmap/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/vr242/CMakeLists.txt
+++ b/simulator/vr242/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/vr292/CMakeLists.txt
+++ b/simulator/vr292/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/simulator/vr483/CMakeLists.txt
+++ b/simulator/vr483/CMakeLists.txt
@@ -24,7 +24,7 @@ file (GLOB INCLUDES "./include/*.h")
 file (GLOB SOURCES "./src/*.cpp")
 
 # Компиляция библиотеки
-add_library (${TARGET} MODULE ${SOURCES} ${INCLUDES})
+add_library (${TARGET} SHARED ${SOURCES} ${INCLUDES})
 
 # Указываем пути поиска заголовков
 target_include_directories (${TARGET} PRIVATE ./include/)

--- a/viewer/src/main.cpp
+++ b/viewer/src/main.cpp
@@ -31,8 +31,6 @@ int main(int argc, char* argv[])
         initialize_logger();
         print_command_line_arguments(argc, argv);
 
-        // Use QCoreApplication instead of QApplication — viewer does not need Qt GUI,
-        // only Qt networking/XML. Avoids NSApp run loop conflict with VSG window on macOS.
         QApplication application(argc, argv);
 
         RouteViewer viewer;


### PR DESCRIPTION
Сборка на macOS
- MODULE -> SHARED во всех 31 CMake плагинов (MODULE создаёт bundle, несовместимый с @rpath при dlopen на macOS)
- Добавлена инструкция сборки (docs/BUILD_MACOS.md)
- Убран старый комментарий