### PR TITLE
Исправления copy-paste ошибок во вьювере

### DIFF
--- a/viewer/src/MyGui.cpp
+++ b/viewer/src/MyGui.cpp
@@ -387,7 +387,7 @@ void MyGui::showSettings() const
         if (params->sun->use_gui_sun_direction)
         {
             ImGui::SliderFloat("Sun azimuth", &(params->sun->azimuth_deg), 0.0f, 360.0f, "%.3f");
-            ImGui::SliderFloat("Sun altitude", &(params->sun->azimuth_deg), 0.0f, 360.0f, "%.3f");
+            ImGui::SliderFloat("Sun altitude", &(params->sun->altitude_deg), -90.0f, 90.0f, "%.3f");
         }
         else
         {

--- a/viewer/src/Settings.cpp
+++ b/viewer/src/Settings.cpp
@@ -185,12 +185,12 @@ void RouteViewer::loadFreeCameraSettings(CfgReader& cfg, const QString& section)
     }
 
     cfg.getDouble(section, "FreeCamRotKeyboard", settings.free_cam_rotate_keyboard);
-    cfg.getDouble(section, "FreeCamRotMouse", settings.free_cam_rotate_keyboard);
+    cfg.getDouble(section, "FreeCamRotMouse", settings.free_cam_rotate_mouse);
     cfg.getDouble(section, "FreeCamHeightStep", settings.free_cam_height_step);
 
     double freeCamFovYCoeff = 1.0;
     cfg.getDouble(section, "FreeCamFovYCoeff", freeCamFovYCoeff);
-    if (freeCamSpeedCoeff > 1.01)
+    if (freeCamFovYCoeff > 1.01)
     {
         settings.free_cam_fovy_coeff = freeCamFovYCoeff;
     }


### PR DESCRIPTION
- Settings: FreeCamRotMouse записывался в free_cam_rotate_keyboard
- Settings: условие для FovY проверяло freeCamSpeedCoeff вместо freeCamFovYCoeff
- MyGui: слайдер Sun altitude менял azimuth_deg вместо altitude_deg, диапазон 0..360→-90..90