### PR TITLE
Исправления ошибок симулятора

### DIFF
--- a/simulator/device/src/autopilot.cpp
+++ b/simulator/device/src/autopilot.cpp
@@ -133,38 +133,15 @@ void Autopilot::velocity_control(double t, double dt)
     // Скорость, заданная по графику
     v_ref = calcTimetableVelocity(t, dt, target_station_dist);
 
-    if (v_ref < 0.1)
-    {
-        // TODO: Не используется нигде
-        int a = 0;
-    }
-
     // Выбираем минимум между текущим ограничением и конструкционной скоростью
     v_ref = min(calcCurrentSpeedLimit(t, dt), v_ref);
-
-    if (v_ref < 0.1)
-    {
-        // TODO: Не используется нигде
-        int a = 0;
-    }
 
     // Рассчитываем скорость по тормозной кривой до следующего ограничения
     // (если оно больше, ну и пусть :))) )
     v_ref = min(v_ref, calcBrakeCurveSpeed(feedback->v_lim_next, feedback->limit_dist));
 
-    if (v_ref < 0.1)
-    {
-        // TODO: Не используется нигде
-        int a = 0;
-    }
-
     // Расчитываем скорость по тормозной кривой до ближайшего сигнала
     v_ref = min(v_ref, calcAlsnSpeed(feedback->alsn_code, feedback->signal_dist, v_target));
-
-    if (v_ref < 0.1)
-    {
-        int a = 0;
-    }
 
     // Если разрешено отправление по графику
     if (is_departure_allowed)
@@ -296,14 +273,14 @@ double Autopilot::calcAlsnSpeed(ALSN alsn_code, double signal_dist, double &v_ta
         break;
 
     case NO_CODE:
-
+    {
         // Тут, по идее, будет происходить торможение, а проверка бдительности
         // не даст сорвать ЭПК
-        v_lim = 40.0; // ????
-
+        constexpr double V_LIM_NO_CODE = 40.0;
+        v_lim = V_LIM_NO_CODE;
         is_alsn_motion_allowed = true;
-
         break;
+    }
 
     case GREEN:
 

--- a/simulator/device/src/brake-mech.cpp
+++ b/simulator/device/src/brake-mech.cpp
@@ -157,7 +157,6 @@ void BrakeMech::ode_system(const state_vector_t &Y,
                            double t)
 {
     Q_UNUSED(t)
-    Q_UNUSED(Y)
 
     dYdt[0] = (Q - k_leak * Y[0]) / V;
 }

--- a/simulator/device/src/coupling.cpp
+++ b/simulator/device/src/coupling.cpp
@@ -54,7 +54,7 @@ void Coupling::setCouplingOperatingState(double state)
 {
     if (state < -Physics::ZERO)
         uncouple();
-    if (state > Physics::ZERO)
+    else if (state > Physics::ZERO)
         couple();
 }
 

--- a/simulator/device/src/device.cpp
+++ b/simulator/device/src/device.cpp
@@ -66,9 +66,9 @@ void Device::step(double t, double dt)
     {
         ode_system(y, dydt, t + static_cast<double>(i) * _dt);
 
-        for (size_t i = 0; i < y.size(); ++i)
+        for (size_t j = 0; j < y.size(); ++j)
         {
-            y[i] = y[i] + dydt[i] * _dt;
+            y[j] = y[j] + dydt[j] * _dt;
         }
     }
 

--- a/simulator/model/src/model.cpp
+++ b/simulator/model/src/model.cpp
@@ -336,9 +336,9 @@ void Model::slotUpdateTrainTimetable(int train_idx)
             {
                 ap->setTimetable(timetable);
 
-                auto vc = topology->getVehicleController(vehicle->getModelIndex());
+                auto& vc = topology->getVehicleController(vehicle->getModelIndex());
 
-                disconnect(ap, &Autopilot::sigGetVehicleTrajPosition, vc, &VehicleController::slotGetVehicleTrajPosition);
+                disconnect(ap, &Autopilot::sigGetVehicleTrajPosition, &vc, &VehicleController::slotGetVehicleTrajPosition);
                 disconnect(ap, &Autopilot::sigIsRouteExists, topology, &Topology::slotIsRouteExists);
                 disconnect(ap, &Autopilot::sigGetRouteLength, topology, &Topology::slotGetRouteLength);
                 disconnect(this, &Model::sigInitTimetable, ap, &Autopilot::slotInitTimeTable);
@@ -352,7 +352,7 @@ void Model::slotUpdateTrainTimetable(int train_idx)
 
                 if (!timetable.stations.empty())
                 {
-                    connect(ap, &Autopilot::sigGetVehicleTrajPosition, vc, &VehicleController::slotGetVehicleTrajPosition);
+                    connect(ap, &Autopilot::sigGetVehicleTrajPosition, &vc, &VehicleController::slotGetVehicleTrajPosition);
                     connect(ap, &Autopilot::sigIsRouteExists, topology, &Topology::slotIsRouteExists);
                     connect(ap, &Autopilot::sigGetRouteLength, topology, &Topology::slotGetRouteLength);
                     connect(this, &Model::sigInitTimetable, ap, &Autopilot::slotInitTimeTable);
@@ -425,7 +425,7 @@ void Model::findNearestVehicles()
             // Ищем другую ПЕ в пределах 10 метров, и дистанцию до неё в данный момент
             double current_distance = 0.0;
             dir_t search_dir = static_cast<dir_t>(veh_dir);
-            int nearest_idx = topology->getVehicleController(idx)->getNearestVehicle(
+            int nearest_idx = topology->getVehicleController(idx).getNearestVehicle(
                 current_distance, DISTANCE_TO_COUPLE_TRAINS, search_dir);
 
             // Если ничего не нашли - дальше делать нечего

--- a/simulator/topology/include/topology.h
+++ b/simulator/topology/include/topology.h
@@ -38,7 +38,7 @@ public:
     bool addTrain(const topology_pos_t &tp, std::vector<Vehicle *> *vehicles);
 
     /// Вернуть контроллер конкретной ПЕ
-    VehicleController *getVehicleController(size_t idx);
+    VehicleController& getVehicleController(size_t idx);
 
     /// Хэш-таблица указателей на вайкл контроллеры по указателю на вайкл
     /// (для удобства смены индекса поезда у контролов из поезда)

--- a/simulator/topology/src/switch.cpp
+++ b/simulator/topology/src/switch.cpp
@@ -359,7 +359,7 @@ void Switch::configure(CfgReader &cfg, QDomNode secNode, traj_list_t &traj_list)
             }
             else
             {
-                Journal::instance()->info("Outcoming trajectories: 2. Parameter <state_bwd> not found, switch is set to plus direction");
+                Journal::instance()->info("Outcoming trajectories: 2. Parameter <state_fwd> not found, switch is set to plus direction");
             }
             ref_state_fwd = state_fwd;
         }

--- a/simulator/topology/src/topology.cpp
+++ b/simulator/topology/src/topology.cpp
@@ -8,6 +8,7 @@
 #include    <vehicle-controller.h>
 #include    <topology.h>
 
+#include    <cassert>
 #include    <QDir>
 #include    <QDirIterator>
 #include    <QFile>
@@ -320,6 +321,8 @@ bool Topology::addTrain(const topology_pos_t &tp, std::vector<Vehicle *> *vehicl
         }
     }
 
+    const size_t initial_vc_count = vehicle_control.size();
+
     for (size_t i = 0; i < vehicles->size(); ++i)
     {
         VehicleController *vc = new VehicleController;
@@ -367,11 +370,21 @@ bool Topology::addTrain(const topology_pos_t &tp, std::vector<Vehicle *> *vehicl
         {
             // По идее мы уже проверили весь путь по топологии,
             // и не должны попасть сюда, но на всякий случай обработаем
-            // В таком случае созданные к этому моменту VehicleController
-            // создадут утечку памяти
-            Journal::instance()->info(QString("Warning: fail to place Vehicle #%1").arg(vehicle_control.size()) +
-                                      " at traj: " + cur_traj->getName() +
-                                      QString(" %1 m from start").arg(traj_coord));
+            delete vc;
+            Journal::instance()->error(QString("Fail to place Vehicle #%1").arg(vehicle_control.size()) +
+                                       " at traj: " + cur_traj->getName() +
+                                       QString(" %1 m from start").arg(traj_coord));
+
+            // Очищаем ранее размещённые контроллеры этого поезда
+            for (auto it = vehicle_control.begin() + initial_vc_count; it != vehicle_control.end(); ++it)
+            {
+                for (auto vt = vc_table.begin(); vt != vc_table.end(); ++vt)
+                {
+                    if (vt->second == *it) { vc_table.erase(vt); break; }
+                }
+                delete *it;
+            }
+            vehicle_control.erase(vehicle_control.begin() + initial_vc_count, vehicle_control.end());
             return false;
         }
    }
@@ -382,9 +395,10 @@ bool Topology::addTrain(const topology_pos_t &tp, std::vector<Vehicle *> *vehicl
 //------------------------------------------------------------------------------
 //
 //------------------------------------------------------------------------------
-VehicleController *Topology::getVehicleController(size_t idx)
+VehicleController& Topology::getVehicleController(size_t idx)
 {
-    return vehicle_control[idx];
+    assert(idx < vehicle_control.size() && "VehicleController index out of range");
+    return *vehicle_control[idx];
 }
 
 //------------------------------------------------------------------------------
@@ -753,13 +767,13 @@ void Topology::step(double t, double dt)
         sw->step(t, dt);
     }
 
-    for (auto& signals_array : {signals_data.line_signals,
-                                signals_data.enter_signals,
-                                signals_data.route_signals,
-                                signals_data.exit_signals,
-                                signals_data.shunt_signals})
+    for (const auto* signals_array : {&signals_data.line_signals,
+                                      &signals_data.enter_signals,
+                                      &signals_data.route_signals,
+                                      &signals_data.exit_signals,
+                                      &signals_data.shunt_signals})
     {
-        for (Signal* const signal : signals_array)
+        for (Signal* const signal : *signals_array)
         {
             if (signal)
             {
@@ -1576,7 +1590,7 @@ void Topology::slotBuildRouteCommand(QByteArray &route_data)
     }
     Journal::instance()->info("Build route: founded from "
                               + rc.trajectory_begin + " to " + rc.trajectory_end
-                              + " through " + QString::number(route.trajectories.size()) + "trajectories");
+                              + " through " + QString::number(route.trajectories.size()) + " trajectories");
 
     set_switchs_by_route(route);
 }
@@ -1628,7 +1642,7 @@ void Topology::slotShuntingRouteCommand(QByteArray &route_data)
     }
     Journal::instance()->info("Build route: founded from "
                               + rc.trajectory_begin + " to " + rc.trajectory_end
-                              + " through " + QString::number(route.trajectories.size()) + "trajectories");
+                              + " through " + QString::number(route.trajectories.size()) + " trajectories");
 
     if (set_switchs_by_route(route))
     {
@@ -1892,6 +1906,9 @@ void Topology::slotGetTrajStateRequest(int vehicle_idx, int station_idx, QString
 //------------------------------------------------------------------------------
 void Topology::slotTrajChangeState(int vehicle_idx, bool is_busy, QString traj_name)
 {
+    if (vehicle_idx < 0 || static_cast<size_t>(vehicle_idx) >= vehicle_control.size())
+        return;
+
     // Определяем поезд, изменивший состояние траектории
     size_t train_idx = vehicle_control[vehicle_idx]->getTrainIndex();
 

--- a/simulator/train/src/train.cpp
+++ b/simulator/train/src/train.cpp
@@ -309,13 +309,14 @@ void Train::couple(double current_distance, bool is_coupling_to_head, bool is_ot
 
                 // На всякий случай актуализируем положение ПЕ в топологии
                 // по старой дуговой координате
-                topology->getVehicleController(model_idx)->setPathCoord(vehicle->getDirection() * new_y[idx]);
+                auto& vc = topology->getVehicleController(model_idx);
+                vc.setPathCoord(vehicle->getDirection() * new_y[idx]);
 
                 vehicle->setDirection(-vehicle->getDirection());
 
                 // Новая дуговая координата
                 new_y[idx] = train_coord + other_veh_distances[i];
-                topology->getVehicleController(model_idx)->setInitPathCoord(vehicle->getDirection() * new_y[idx]);
+                vc.setInitPathCoord(vehicle->getDirection() * new_y[idx]);
                 train_coord = new_y[idx];
             }
 
@@ -369,11 +370,12 @@ void Train::couple(double current_distance, bool is_coupling_to_head, bool is_ot
 
                 // На всякий случай актуализируем положение ПЕ в топологии
                 // по старой дуговой координате
-                topology->getVehicleController(model_idx)->setPathCoord(vehicle->getDirection() * new_y[idx]);
+                auto& vc = topology->getVehicleController(model_idx);
+                vc.setPathCoord(vehicle->getDirection() * new_y[idx]);
 
                 // Новая дуговая координата
                 new_y[idx] = train_coord + other_veh_distances[i - 1];
-                topology->getVehicleController(model_idx)->setInitPathCoord(vehicle->getDirection() * new_y[idx]);
+                vc.setInitPathCoord(vehicle->getDirection() * new_y[idx]);
                 train_coord = new_y[idx];
             }
 
@@ -435,11 +437,12 @@ void Train::couple(double current_distance, bool is_coupling_to_head, bool is_ot
 
                 // На всякий случай актуализируем положение ПЕ в топологии
                 // по старой дуговой координате
-                topology->getVehicleController(model_idx)->setPathCoord(vehicle->getDirection() * new_y[idx]);
+                auto& vc = topology->getVehicleController(model_idx);
+                vc.setPathCoord(vehicle->getDirection() * new_y[idx]);
 
                 // Новая дуговая координата
                 new_y[idx] = train_coord - other_veh_distances[i];
-                topology->getVehicleController(model_idx)->setInitPathCoord(vehicle->getDirection() * new_y[idx]);
+                vc.setInitPathCoord(vehicle->getDirection() * new_y[idx]);
                 train_coord = new_y[idx];
             }
 
@@ -478,13 +481,14 @@ void Train::couple(double current_distance, bool is_coupling_to_head, bool is_ot
 
                 // На всякий случай актуализируем положение ПЕ в топологии
                 // по старой дуговой координате
-                topology->getVehicleController(model_idx)->setPathCoord(vehicle->getDirection() * other_y[idx]);
+                auto& vc = topology->getVehicleController(model_idx);
+                vc.setPathCoord(vehicle->getDirection() * other_y[idx]);
 
                 vehicle->setDirection(-vehicle->getDirection());
 
                 // Новая дуговая координата
                 new_y[new_ode_order] = train_coord - other_veh_distances[i - 1];
-                topology->getVehicleController(model_idx)->setInitPathCoord(vehicle->getDirection() * new_y[new_ode_order]);
+                vc.setInitPathCoord(vehicle->getDirection() * new_y[new_ode_order]);
                 train_coord = new_y[new_ode_order];
 
                 vehicle->setTrainIndex(train_idx);
@@ -965,8 +969,9 @@ void Train::slotStep(const simulator_time_t& current_time, const double& integra
             {
                 size_t model_idx = vehicle->getModelIndex();
                 size_t idx = vehicle->getStateIndex();
-                topology->getVehicleController(model_idx)->setPathCoord(vehicle->getDirection() * y[idx]);
-                *(vehicle->getProfilePoint()) = topology->getVehicleController(model_idx)->getPosition();
+                auto& vc = topology->getVehicleController(model_idx);
+                vc.setPathCoord(vehicle->getDirection() * y[idx]);
+                *(vehicle->getProfilePoint()) = vc.getPosition();
             }
         }
     }
@@ -1148,7 +1153,12 @@ bool Train::loadTrain(QString cfg_path, const init_data_t& init_data, int model_
                 vehicles.push_back(vehicle);
             }
 
-            vehicle_node = cfg.getNextSection();
+            // Advance to next <Vehicle> sibling directly, bypassing
+            // CfgReader::curNode which can be corrupted by nested calls.
+            QDomNode next = vehicle_node.nextSibling();
+            while (!next.isNull() && next.nodeName() != vehicle_node.nodeName())
+                next = next.nextSibling();
+            vehicle_node = next;
         }
     }
     else


### PR DESCRIPTION
- device: переименована переменная внутреннего цикла (shadowing i→j)
- coupling: if→else if для взаимоисключающих операций сцепки/расцепки
- autopilot: удалён мёртвый код, именованная константа V_LIM_NO_CODE
- brake-mech: убран некорректный Q_UNUSED(Y)
- switch: исправлено сообщение в логе (state_bwd→state_fwd)
- topology: утечка VehicleController при неудачном размещении, getVehicleController возвращает ссылку вместо указателя, итерация сигналов по указателям вместо копий, проверка границ в slotTrajChangeState, пробел в сообщении лога маршрутов
- train: загрузка многогрупповых поездов через ручной обход XML-узлов